### PR TITLE
Create Missing Tiles from Rescaling Existing Tiles

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,10 +7,6 @@ ignore =
     D104,
     # D401: Docstring first line should be imperative
     D401,
-    # D101 Missing docstring in public class
-    D101,
-    # D102 Missing docstring in public method
-    D102,
     # D503 line break before binary operator
     W503,
     # D504 line break after binary operator

--- a/src/tile_cache.py
+++ b/src/tile_cache.py
@@ -2,55 +2,264 @@ from abc import ABC, abstractmethod
 from io import BytesIO
 
 import boto3
-from botocore.exceptions import ClientError
+import mercantile
 from PIL import Image
 
 
 class TileCache(ABC):
+    """Abstract class for tile cache."""
+
     @abstractmethod
     def get_tile(self, x: int, y: int, z: int, year: int) -> Image:
+        """Get tile image from cache.
+
+        Parameters
+        ----------
+        x: int
+            x coordinate of tile
+        y: int
+            y coordinate of tile
+        z: int
+            zoom level of tile
+        year: int
+            naip year
+
+        Returns
+        -------
+        Image
+            image if tile found in cache, None if not
+
+        """
         pass
 
     @abstractmethod
     def save_tile(self, x: int, y: int, z: int, year: int, image: Image) -> None:
+        """Save tile image to cache.
+
+        Parameters
+        ----------
+        x: int
+            x coordinate of tile
+        y: int
+            y coordinate of tile
+        z: int
+            zoom level of tile
+        year: int
+            naip year
+        image: Image
+            tile image
+
+        Returns
+        -------
+            None
+        """
         pass
 
     @abstractmethod
     def contains_tile(self, x: int, y: int, z: int, year: int) -> bool:
+        """Checks if tile exists in cache.
+
+        Parameters
+        ----------
+        x: int
+            x coordinate of tile
+        y: int
+            y coordinate of tile
+        z: int
+            zoom level of tile
+        year: int
+            naip year
+
+        Returns
+        -------
+        bool
+            True if tile exists, False if not exists
+
+        """
         pass
+
+    def get_tile_from_downscaling(self, x: int, y: int, z: int, year: int) -> Image:
+        """Create tile via merging & downscaling tiles from the next zoom level.
+
+        Parameters
+        ----------
+        x: int
+            x coordinate of tile
+        y: int
+            y coordinate of tile
+        z: int
+            zoom level of tile
+        year: int
+            naip year
+
+        Returns
+        -------
+        Image
+            image if downscaling was possible, None otherwise
+        """
+        children_tile_images = []
+        for child_tile in mercantile.children(x, y, z):
+            chile_tile_image = self.get_tile(
+                child_tile.x, child_tile.y, child_tile.z, year
+            )
+            if not chile_tile_image:
+                return None
+            children_tile_images.append(chile_tile_image)
+
+        downscaled_tile_img = Image.new("RGB", (512, 512))
+        downscaled_tile_img.paste(children_tile_images[0], (0, 0))
+        downscaled_tile_img.paste(children_tile_images[1], (256, 0))
+        downscaled_tile_img.paste(children_tile_images[3], (0, 256))
+        downscaled_tile_img.paste(children_tile_images[2], (256, 256))
+        return downscaled_tile_img.resize((256, 256))
+
+    def get_tile_from_upscaling(self, x: int, y: int, z: int, year: int) -> Image:
+        """Create tile via cropping & upscaling the tile from the previous zoom level.
+
+        Parameters
+        ----------
+        x: int
+            x coordinate of tile
+        y: int
+            y coordinate of tile
+        z: int
+            zoom level of tile
+        year: int
+            naip year
+
+        Returns
+        -------
+        Image
+            image if upscaling was possible, None otherwise
+        """
+        parent_tile = mercantile.parent(x, y, z)
+        parent_tile_image = self.get_tile(
+            parent_tile.x, parent_tile.y, parent_tile.z, year
+        )
+        if not parent_tile_image:
+            # cant do anything without the parent tile...
+            return None
+
+        # determine what region in the parent tile that should be cropped
+        quadrant = mercantile.children(parent_tile).index(mercantile.Tile(x, y, z))
+        if quadrant == 0:
+            crop_region = (0, 0, 128, 128)
+        elif quadrant == 1:
+            crop_region = (128, 0, 256, 128)
+        elif quadrant == 3:
+            crop_region = (0, 128, 128, 256)
+        else:
+            crop_region = (128, 128, 256, 256)
+
+        # crop region from parent tile and resize to standard tile size
+        return parent_tile_image.crop(crop_region).resize((256, 256))
 
 
 class S3TileCache(TileCache):
-    def __init__(self, bucket: str):
+    """S3 implementation of TileCache."""
+
+    def __init__(
+        self, bucket: str, downscale_max_zoom: int = 10, upscale_min_zoom: int = 18
+    ):
         """Initialize S3TileCache instance.
 
         Parameters
         ----------
         bucket: str
-          s3 bucket name to be used as tile cache
+            S3 bucket name to be used as tile cache
+        downscale_max_zoom: int
+            max zoom level where attempts to create missing tile from downscaling will
+            kick-in.
+        upscale_min_zoom: int
+            min zoom level where attempts to create missing tile from upscaling will
+            kick-in.
         """
         self.s3 = boto3.resource("s3").Bucket(bucket)
+        self.downscale_max_zoom = downscale_max_zoom
+        self.upscale_min_zoom = upscale_min_zoom
 
     def _get_key(self, x: int, y: int, z: int, year: int):
         return f"{year}/{z}/{y}/{x}.jpg"
 
     def get_tile(self, x: int, y: int, z: int, year: int) -> Image:
-        try:
+        """Get tile image from cache.
+
+        Parameters
+        ----------
+        x: int
+            x coordinate of tile
+        y: int
+            y coordinate of tile
+        z: int
+            zoom level of tile
+        year: int
+            naip year
+
+        Returns
+        -------
+        Image
+            image if tile found in cache, None if not
+
+        """
+        if self.contains_tile(x, y, z, year):
             file_key = self._get_key(x, y, z, year)
             image_bytes = BytesIO(self.s3.Object(key=file_key).get()["Body"].read())
             return Image.open(image_bytes)
-        except ClientError as ex:
-            if ex.response["Error"]["Code"] == "NoSuchKey":
-                return None
-            else:
-                raise
+
+        rescaled_tile = None
+        if z <= self.downscale_max_zoom:
+            rescaled_tile = self.get_tile_from_downscaling(x, y, z, year)
+        elif z >= self.upscale_min_zoom:
+            rescaled_tile = self.get_tile_from_upscaling(x, y, z, year)
+        if rescaled_tile:
+            self.save_tile(x, y, z, year, rescaled_tile)
+
+        return rescaled_tile
 
     def save_tile(self, x: int, y: int, z: int, year: int, image: Image) -> None:
+        """Save tile image to cache.
+
+        Parameters
+        ----------
+        x: int
+            x coordinate of tile
+        y: int
+            y coordinate of tile
+        z: int
+            zoom level of tile
+        year: int
+            naip year
+        image: Image
+            tile image
+
+        Returns
+        -------
+            None
+        """
         file_key = self._get_key(x, y, z, year)
         image_bytes = BytesIO()
         image.save(image_bytes, format="JPEG")
         self.s3.Object(key=file_key).put(Body=image_bytes.getvalue())
 
     def contains_tile(self, x: int, y: int, z: int, year: int) -> bool:
+        """Checks if tile exists in cache.
+
+        Parameters
+        ----------
+        x: int
+            x coordinate of tile
+        y: int
+            y coordinate of tile
+        z: int
+            zoom level of tile
+        year: int
+            naip year
+
+        Returns
+        -------
+        bool
+            True if tile exists, False if not exists
+
+        """
         file_key = self._get_key(x, y, z, year)
         return len(list(self.s3.objects.filter(Prefix=file_key))) > 0

--- a/tests/unit/test_tile_cache.py
+++ b/tests/unit/test_tile_cache.py
@@ -98,3 +98,9 @@ def test_s3_upscale_tile_null(s3_tile_cache, tile_image):
     tile = mercantile.Tile(12, 12, 12)
     tile_image = s3_tile_cache.get_tile_from_upscaling(tile.x, tile.y, tile.z, 2099)
     assert tile_image is None
+
+
+def test_s3_save_rescaled_tile(s3_tile_cache, tile_image):
+    """Test confirms saving tile with is_rescaled metadata works."""
+    s3_tile_cache.save_tile(1, 2, 3, 2099, tile_image, is_rescaled=True)
+    assert s3_tile_cache.contains_tile(1, 2, 3, 2099)

--- a/tests/unit/test_tile_cache.py
+++ b/tests/unit/test_tile_cache.py
@@ -1,6 +1,7 @@
 import uuid
 
 import boto3
+import mercantile
 import numpy as np
 import pytest
 from PIL import Image
@@ -10,6 +11,7 @@ from src.tile_cache import S3TileCache
 
 @pytest.fixture(scope="module")
 def s3_tile_cache():
+    """Return S3TileCache instance backed by bucket created for this run of tests."""
     # create a bucket specifically for testing
     test_bucket_name = f"aws-naip-tile-server-test-{uuid.uuid4()}"
     s3 = boto3.resource("s3")
@@ -27,26 +29,72 @@ def s3_tile_cache():
     bucket.delete()
 
 
-def test_s3_save_tile(s3_tile_cache):
-    imarray = np.random.rand(100, 100, 3) * 255
-    tile_image = Image.fromarray(imarray.astype("uint8")).convert("RGB")
+@pytest.fixture()
+def tile_image():
+    """Return random tile sized image."""
+    imarray = np.random.rand(256, 256, 3) * 255
+    return Image.fromarray(imarray.astype("uint8")).convert("RGB")
+
+
+def test_s3_save_tile(s3_tile_cache, tile_image):
+    """Test confirms saving tile works."""
     s3_tile_cache.save_tile(1, 1, 1, 2099, tile_image)
     assert s3_tile_cache.contains_tile(1, 1, 1, 2099)
 
 
 def test_s3_get_existing_tile(s3_tile_cache):
+    """Test confirms getting cached tile returns image."""
     tile_image = s3_tile_cache.get_tile(1, 1, 1, 2099)
     assert tile_image is not None
 
 
 def test_s3_get_nonexisting_tile(s3_tile_cache):
+    """Test confirms getting non-cached tile returns None."""
     tile_image = s3_tile_cache.get_tile(1, 1, 5, 2099)
     assert tile_image is None
 
 
 def test_s3_contain_existing_tile(s3_tile_cache):
+    """Test confirms checking existence of cached tile returns True."""
     assert s3_tile_cache.contains_tile(1, 1, 1, 2099)
 
 
 def test_s3_contain_nonexisting_tile(s3_tile_cache):
+    """Test confirms checking existence of non-cached tile returns False."""
     assert not s3_tile_cache.contains_tile(1, 1, 5, 2099)
+
+
+def test_s3_downscale_tile(s3_tile_cache, tile_image):
+    """Test confirms that downscaling will return Image if children tiles in cache."""
+    tile = mercantile.Tile(10, 10, 10)
+    for children_tile in mercantile.children(tile):
+        s3_tile_cache.save_tile(
+            children_tile.x, children_tile.y, children_tile.z, 2099, tile_image
+        )
+    tile_image = s3_tile_cache.get_tile_from_downscaling(tile.x, tile.y, tile.z, 2099)
+    assert tile_image is not None
+
+
+def test_s3_downscale_tile_null(s3_tile_cache, tile_image):
+    """Test confirms that downscaling will return None if children tiles don't exist."""
+    tile = mercantile.Tile(8, 8, 8)
+    tile_image = s3_tile_cache.get_tile_from_downscaling(tile.x, tile.y, tile.z, 2099)
+    assert tile_image is None
+
+
+def test_s3_upscale_tile(s3_tile_cache, tile_image):
+    """Test confirms that upscaling will return Image if parent tile in cache."""
+    tile = mercantile.Tile(11, 11, 11)
+    parent_tile = mercantile.parent(tile)
+    s3_tile_cache.save_tile(
+        parent_tile.x, parent_tile.y, parent_tile.z, 2099, tile_image
+    )
+    tile_image = s3_tile_cache.get_tile_from_upscaling(tile.x, tile.y, tile.z, 2099)
+    assert tile_image is not None
+
+
+def test_s3_upscale_tile_null(s3_tile_cache, tile_image):
+    """Test confirms that upscaling will return None if parent tile not in cache."""
+    tile = mercantile.Tile(12, 12, 12)
+    tile_image = s3_tile_cache.get_tile_from_upscaling(tile.x, tile.y, tile.z, 2099)
+    assert tile_image is None


### PR DESCRIPTION
### What
It's possible to create tiles, from existing tiles of other zoom levels.  For example, a zoom level 9 tile could be created from its 4 zoom level 10 'children' tiles (aka down-scaling).  Likewise, its possible to create 4 zoom level 10 tiles from their shared zoom level 9 'parent' tile (aka up-scaling)

### Why
Creating tiles from AWS geotiffs from zoom level 11 and lower will take progressively longer, because the number of geotiffs that need to be accessed increases for each step down on zoom levels.  Down-sampling existing tiles will eliminate the need to access many AWS geotiffs, greatly reducing tile creation time.  

### How
The S3TileCache class gets 2 new properties:

1. **downscale_max_zoom (int):**  max zoom level where attempts to create missing tile from down-scaling will kick-in.
2. **upscale_min_zoom (int):**  min zoom level where attempts to creating missing tile from up-scaling will kick-in.

If a requested tile does not exist in the cache, but rescaling is possible (respecting these above properties) - rescaling will occur and rescaled tile is saved to cache with custom metadata indicating it was produced via rescaling.